### PR TITLE
Add YouTube videos to speaker modals

### DIFF
--- a/_data/schedule.yml
+++ b/_data/schedule.yml
@@ -7,6 +7,7 @@
   track: RB105
   lang: EN
   speaker_id: D11C51
+  video_id: UJUOhyMEb8c
   speaker_avatar: akihito_uesada.jpg
   speaker_name: Akihito Uesada
   speaker_github: 
@@ -22,6 +23,7 @@
   day: 1
   track: RB105
   lang: EN
+  video_id: dXoo5MtUVvk
   speaker_id: C9493B
   speaker_avatar: matz.jpg
   speaker_name: MATSUMOTO Yukihiro (Matz) 
@@ -47,6 +49,7 @@
   day: 1
   track: RB105
   lang: EN
+  video_id: V8O1CbGpDfI
   speaker_id: YTJHQ7
   speaker_avatar: segiddins.jpg
   speaker_name: Samuel Giddins
@@ -63,6 +66,7 @@
   day: 1
   track: TR209
   lang: EN
+  video_id: _WGueO88v3o
   speaker_id: WVCWXV
   speaker_avatar: KuokkanenSampo.jpg
   speaker_name: Sampo Kuokkanen
@@ -93,6 +97,7 @@
   day: 1
   track: TR209
   lang: EN
+  video_id: AI6unRJNZ8c
   speaker_id: AFH9W3
   speaker_avatar: hasumikin.jpg
   speaker_name: Hitoshi HASUMI
@@ -123,6 +128,7 @@
   day: 1
   track: TR209
   lang: EN
+  video_id: -fYhI7qM8yY
   speaker_id: TD3ZDW
   speaker_avatar: crplanas.jpg
   speaker_name: Cristian Planas
@@ -153,6 +159,7 @@
   day: 1
   track: TR209
   lang: EN
+  video_id: 3RwPybQOSEg
   speaker_id: KLEUNM
   speaker_avatar: s01.jpg
   speaker_name: Ryo Kajiwara
@@ -183,6 +190,7 @@
   day: 1
   track: TR209
   lang: EN
+  video_id: BQDLzYVyHbA
   speaker_id: K793LW
   speaker_avatar: kaz0505.jpg
   speaker_name: Kazuaki TANAKA
@@ -289,6 +297,7 @@
   day: 2
   track: TR209
   lang: cht
+  video_id: ObpSO4_-n9Y
   speaker_id: TY3ELY
   speaker_avatar: EtrexKuo.jpg
   speaker_name: 卡米哥 / Etrex Kuo
@@ -331,6 +340,7 @@
   day: 2
   track: TR209
   lang: EN
+  video_id: CqbBoA7BE3A
   speaker_id: QWF9SF
   speaker_avatar: ioquatix.jpg
   speaker_name: Samuel Williams
@@ -361,6 +371,7 @@
   day: 2
   track: TR209
   lang: EN
+  video_id: 8h89q2rym1U
   speaker_id: J7KBSL
   speaker_avatar: skyksandr.jpg
   speaker_name: Aleksandr Kunin
@@ -391,6 +402,7 @@
   day: 2
   track: TR209
   lang: EN
+  video_id: F9k32XvpOkA
   speaker_id: KVTZHB
   speaker_avatar: ydah_.jpg
   speaker_name: Yudai Takada
@@ -421,6 +433,7 @@
   day: 2
   track: TR209
   lang: cht
+  video_id: Qscc50w2_kg
   speaker_id: UNVNAN
   speaker_avatar: cindyliu923.jpg
   speaker_name: Cindy Liu
@@ -452,6 +465,7 @@
   day: 2
   track: TR209
   lang: EN
+  video_id: gD85IyOwD34
   speaker_id: KRTWYM
   speaker_avatar: Envek.jpg
   speaker_name: Andrey Novikov
@@ -482,6 +496,7 @@
   day: 2
   track: TR209
   lang: cht
+  video_id: oItkKKQ0_aU
   subject: "Crafting AI-Driven Workflow for Ruby"
   speaker_id: X338CA
   speaker_avatar: elct9620.jpg

--- a/_includes/speaker_modals.html
+++ b/_includes/speaker_modals.html
@@ -105,6 +105,18 @@
               {{ schedule.abstract | markdownify }}
             </p>
           </div>
+          {% if schedule.video_id %}
+          <div class="mt-4 aspect-video w-full">
+            <iframe
+              class="w-full h-full rounded-lg"
+              src="https://www.youtube.com/embed/{{ schedule.video_id }}"
+              title="{{ schedule.subject }}"
+              frameborder="0"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              allowfullscreen
+            ></iframe>
+          </div>
+          {% endif %}
           <!--
           <div
             class="px-3 py-1 text-green-normal bg-green-light border border-green-normal rounded-md w-fit"


### PR DESCRIPTION
## Summary
- Matched 12 session recordings from the [RubyConf TW YouTube playlist](https://www.youtube.com/playlist?list=PLqfib4St70XNYozamLA5UaK-ALDvZeneH) to schedule entries and added `video_id` to `_data/schedule.yml`
- Added a responsive YouTube embedded iframe in `_includes/speaker_modals.html` below the abstract section (only shown when `video_id` exists)
- 3 sessions (s7, s8, s9) have no matching video in the playlist yet

## Test plan
- [ ] Run `bundle exec jekyll serve` and verify the site builds
- [ ] Click on a speaker with a video (e.g. Sampo Kuokkanen, Hitoshi HASUMI) and confirm the YouTube player appears below the abstract
- [ ] Click on a speaker without a video (e.g. Hayao Kimura) and confirm no broken iframe appears
- [ ] Verify the video player is responsive on mobile viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)